### PR TITLE
pin pnpm to be compatible with lockfile version, add wget for healt checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,27 @@
 FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN : \
+    && corepack enable \
+    && corepack prepare pnpm@10.11.0 --activate
 COPY . /app
 WORKDIR /app
 
-# FROM base AS prod-deps
-# RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
-
 FROM base AS build
 ENV IS_DOCKER=true
+# even though it's not in vercel, we need to override the production URL
+ENV VERCEL_PROJECT_PRODUCTION_URL=dashboard.data2resilience.de
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run build
 
-FROM base
-# COPY --from=prod-deps /app/node_modules /app/node_modules
+FROM node:22-slim
+RUN : \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/build build/
 EXPOSE 3000
 CMD [ "node", "build" ]


### PR DESCRIPTION
We need `wget` for doing health checks on the container hence it has to be installed.

Creating the final image from the base image unnecessarily adds 100 MB to the image - afaict we only need the build directory and hence can start from the slim-image again.

Also the lockfile version 6 seems to be incompatible with pnpm > 9 so we need to pin it (like I did) or upgrade the lockfile version to > 6.