### PR TITLE
fix a bug where no available data lead to an error

### DIFF
--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -92,12 +92,15 @@ export const api = (customFetch = fetch) => ({
 							vmax: null,
 							vmin: null
 						})
-				})
+				}).nullable()
 			})
 		);
 		return {
 			data: data.data,
-			visualization: data.visualization[params.param]
+			visualization:
+				data.visualization && data.visualization[params.param]
+					? data.visualization[params.param]
+					: null
 		};
 	},
 	downloadStationData: async (params: { id: string }) => {


### PR DESCRIPTION
The user saw a box indicating an error. When there is no data, no visualization suggestion is present/it is null

**Before**:
![image](https://github.com/user-attachments/assets/ca7c58c0-cd64-4bd8-8a99-5192276643ab)


**After**:
![image](https://github.com/user-attachments/assets/56ef8e1d-5cc0-413f-9bf5-4f520b87bc1a)
